### PR TITLE
Add gibberish module to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN cd /PrairieLearn \
     && yarn install --frozen-lockfile \
     && yarn cache clean
 
+RUN pip install gibberish
 # NOTE: Modify .dockerignore to whitelist files/directories to copy.
 COPY . /PrairieLearn/
 


### PR DESCRIPTION
Adds the Pip install to the dockerfile when creating the image.
If a user doesn't want to use the dockerfile and only use the prairielearn image, you can install by attaching to the docker container and running `pip install gibberish`.